### PR TITLE
update for splitters in task assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+1_fetch/tmp/*
+.remake/
+!1_fetch/tmp/state_splits.yml
+3_visualize/out/*.png

--- a/123_state_tasks.R
+++ b/123_state_tasks.R
@@ -1,5 +1,6 @@
 do_state_tasks <- function(remakefile, oldest_active_sites) {
 
+  split_inventory(summary_file = '1_fetch/tmp/state_splits.yml', sites_info = oldest_active_sites)
   # Define task table rows
   tasks <- oldest_active_sites$state_cd
 
@@ -10,7 +11,7 @@ do_state_tasks <- function(remakefile, oldest_active_sites) {
       sprintf('%s_data', task_name)
     },
     command = function(task_name, ...){
-      sprintf("get_site_data(oldest_active_sites, state = I('%s'), parameter = parameter)", task_name)
+      sprintf("get_site_data('1_fetch/tmp/inventory_%s.tsv', state = I('%s'), parameter = parameter)", task_name, task_name)
     }
   )
 
@@ -31,4 +32,18 @@ do_state_tasks <- function(remakefile, oldest_active_sites) {
 
   scmake(tools::file_path_sans_ext(remakefile), remake_file=remakefile)
   return()
+}
+
+
+split_inventory <- function(summary_file, sites_info) {
+
+  files_out <- c()
+  for (state_abr in sites_info$state_cd){
+    this_file <- sprintf('1_fetch/tmp/inventory_%s.tsv', state_abr)
+    filter(sites_info, state_cd == state_abr) %>%
+      readr::write_tsv(path = this_file)
+    files_out <- c(files_out, this_file)
+  }
+
+  scipiper::sc_indicate(ind_file = summary_file, data_file = sort(files_out))
 }

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -25,24 +25,36 @@ targets:
       - MN_data
       - MI_data
       - IL_data
+      - IN_data
+      - IA_data
 
   # --- WI --- #
   
   WI_data:
-    command: get_site_data(oldest_active_sites, state = I('WI'), parameter = parameter)
+    command: get_site_data('1_fetch/tmp/inventory_WI.tsv', state = I('WI'), parameter = parameter)
 
   # --- MN --- #
   
   MN_data:
-    command: get_site_data(oldest_active_sites, state = I('MN'), parameter = parameter)
+    command: get_site_data('1_fetch/tmp/inventory_MN.tsv', state = I('MN'), parameter = parameter)
 
   # --- MI --- #
   
   MI_data:
-    command: get_site_data(oldest_active_sites, state = I('MI'), parameter = parameter)
+    command: get_site_data('1_fetch/tmp/inventory_MI.tsv', state = I('MI'), parameter = parameter)
 
   # --- IL --- #
   
   IL_data:
-    command: get_site_data(oldest_active_sites, state = I('IL'), parameter = parameter)
+    command: get_site_data('1_fetch/tmp/inventory_IL.tsv', state = I('IL'), parameter = parameter)
+
+  # --- IN --- #
+  
+  IN_data:
+    command: get_site_data('1_fetch/tmp/inventory_IN.tsv', state = I('IN'), parameter = parameter)
+
+  # --- IA --- #
+  
+  IA_data:
+    command: get_site_data('1_fetch/tmp/inventory_IA.tsv', state = I('IA'), parameter = parameter)
 

--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,6 +1,6 @@
 # download data for each site
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info_file, state, parameter) {
+  site_info <- readr::read_tsv(site_info_file, col_types='cccddcDDi')
   message(sprintf('Retrieving data for site %s', site_info$site_no))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/1_fetch/tmp/state_splits.yml
+++ b/1_fetch/tmp/state_splits.yml
@@ -1,0 +1,7 @@
+1_fetch/tmp/inventory_IA.tsv: 81c56b671cb8b0da7a680e6eeae7a057
+1_fetch/tmp/inventory_IL.tsv: 8c08acae59fad6cb58df7e3b06030180
+1_fetch/tmp/inventory_IN.tsv: 65c55263e5e75de409fec34c5265ac00
+1_fetch/tmp/inventory_MI.tsv: 33b666254d3384925042f2c6aec6853b
+1_fetch/tmp/inventory_MN.tsv: e8830d03b5fc6c6b2025681d5d6807b5
+1_fetch/tmp/inventory_WI.tsv: 54f26fdd6877e3f173da020ed59bd28d
+

--- a/remake.yml
+++ b/remake.yml
@@ -19,7 +19,7 @@ targets:
 
   # Configuration
   states:
-    command: c(I(c('WI','MN','MI','IL')))
+    command: c(I(c('WI','MN','MI','IL', 'IN','IA')))
   parameter:
     command: c(I('00060'))
 


### PR DESCRIPTION
The inventory files were rebuilt when I added the new states, but it didn't rebuild already-pulled data for the other states. 